### PR TITLE
Use multistage build for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.6 as build
 
 RUN gem install bundler
 
@@ -7,6 +7,12 @@ WORKDIR /app
 COPY gems.* /app/
 RUN bundle install
 
+FROM ruby:2.6-alpine
+
+WORKDIR /app
+
+COPY --from=build /usr/local/bundle/ /usr/local/bundle/
+COPY gems.* /app/
 COPY *.rb /app/
 COPY src/*.rb /app/src/
 


### PR DESCRIPTION
Dramatically reduce size of the docker image. From approx 800Mb to 80Mb